### PR TITLE
Fixes and adoptions, custom pre/post actions

### DIFF
--- a/just-backup-btrfs
+++ b/just-backup-btrfs
@@ -21,6 +21,13 @@ class Just_backup_btrfs {
 	 * @var string
 	 */
 	protected $binary;
+	protected $btrfs_cmd;
+	protected $btrfs_send_cmd;
+	protected $btrfs_receive_cmd;
+	protected $action_snapshot_post;
+	protected $action_send_pre;
+	protected $action_receive_post;
+	protected $skip_auto_mounting;
 	/**
 	 * @param array $config
 	 *
@@ -30,7 +37,11 @@ class Just_backup_btrfs {
 		if (!$config) {
 			exit("Incorrect configuration, aborted\n");
 		}
-		// TODO: if $btrfs_cmd is set, this is not needed
+		/* Run trap_exit() on any exit from do_backup()
+		 * to guarantee thet post-snapshot action is performed,
+		 * e.g. volume is unmounted */
+		register_shutdown_function(array($this, 'trap_exit'));
+		// TODO: if $this->btrfs_cmd is set, this is not needed
 		$this->config = $config;
 		if (file_exists('/usr/sbin/btrfs')) {
 			$this->binary = '/usr/sbin/btrfs';
@@ -40,6 +51,11 @@ class Just_backup_btrfs {
 			$this->binary = '/bin/btrfs';
 		} else {
 			throw new RuntimeException("Can't find btrfs binary");
+		}
+	}
+	function trap_exit () {
+		if ($this->action_snapshot_post) {
+			$this->exec("$this->action_snapshot_post", "Running post-snapshot action");
 		}
 	}
 	function backup () {
@@ -59,13 +75,45 @@ class Just_backup_btrfs {
 		$destination          = $config['destination_within_partition'];
 		$minimum_delete_count = $config['minimum_delete_count'];
 		/* custom btrfs command for local operations */
-		$btrfs_cmd            = @$config['btrfs_cmd'] ?: $this->binary;
+		$this->btrfs_cmd      = @$config['btrfs_cmd'] ?: $this->binary;
 		/* custom commands in `btrfs send | btrfs receive` pipe,
 		 * allow to use ssh on both sides of the pipe,
 		 * example: "btrfs_send_cmd" : "ssh username@host btrfs" */
-		$btrfs_send_cmd       = @$config['btrfs_send_cmd'] ?: $this->binary;
-		$btrfs_receive_cmd    = @$config['btrfs_receive_cmd'] ?: $this->binary;
+		$this->btrfs_send_cmd  = @$config['btrfs_send_cmd'] ?: $this->binary;
+		$this->btrfs_receive_cmd = @$config['btrfs_receive_cmd'] ?: $this->binary;
 		// TODO: check that commands are really available
+		/* shell command to execute before snapshotting,
+		 * e.g. mount btrfs volume (useful when only subvolumes
+		 * are mounted, but the root is not) */
+		$action_snapshot_pre  = @$config['action_snapshot_pre'] ?: null;
+		/* shell command to execute on any exit,
+		 * e.g. umount btrfs volume */
+		$this->action_snapshot_post = @$config['action_snapshot_post'] ?: null;
+		/* shell command to execute before `[ssh] btrfs send | [ssh] btrfs receive`,
+		 * useful e.g. to mount sth on external server via SSH */
+		$this->action_send_pre      = @$config['action_send_pre'] ?: null;
+		/* shell command to execure after `[ssh] btrfs send | [ssh] btrfs receive`,
+		 * e.g. umount sth on external server via SSH */
+		$this->action_receive_post  = @$config['action_receive_post'] ?: null;
+		/* skip attempts to mount subvol=/ (root subvolume) before
+		 * `btrfs send | btrfs receive`, e.g. if propper mounting was
+		 * defined in $action* variables;
+		 * possible values: "yes", "true", "1";
+		 * other values and being not set are equal to false */
+		$this->skip_auto_mounting = @$config['skip_auto_mounting'] ?: null;
+		if ($this->skip_auto_mounting and (strcasecmp($this->skip_auto_mounting, "yes") or
+		                             strcasecmp($this->skip_auto_mounting, "true") or
+		                             strcasecmp($this->skip_auto_mounting, "1"))) {
+			$this->skip_auto_mounting = 1;
+		} else {
+			$this->skip_auto_mounting = 0;
+		}
+
+		/* execute it here early enough so that $history_db is not created outside
+		 * of target mountpoint if sth is mounted in $action_snapshot_pre */
+		if ($action_snapshot_pre) {
+			$this->exec("$action_snapshot_pre", "Running pre-snapshot action");
+		}
 
 		$history_db = $this->init_database($destination);
 		if (!$history_db) {
@@ -104,7 +152,7 @@ class Just_backup_btrfs {
 			return;
 		}
 
-		$this->exec("$btrfs_cmd subvolume snapshot -r \"$source\" \"$destination/$snapshot\"");
+		$this->exec($this->btrfs_cmd . ' subvolume snapshot -r "' . $source . '" "' . $destination . '/' . $snapshot . '"');
 		$this->exec("sync"); // To actually write snapshot to disk
 		if (!file_exists("$destination/$snapshot")) {
 			echo "Snapshot creation for $source failed\n";
@@ -239,7 +287,7 @@ class Just_backup_btrfs {
 
 		$target_mount_point         = "/tmp/just_backup_btrfs_".md5($partition);
 		$destination_external_fixed = $target_mount_point.$destination_external_fixed;
-		if (!is_dir($target_mount_point)) {
+		if (!$this->skip_auto_mounting and (!is_dir($target_mount_point))) {
 			mkdir($target_mount_point);
 			$this->exec(
 				"mount -o subvol=/,$mount_options /$partition $target_mount_point",
@@ -250,20 +298,23 @@ class Just_backup_btrfs {
 		}
 		unset($mount_point_options, $partition, $mount_point, $mount_options);
 
-		if (!isset($destination_external_fixed, $target_mount_point)) {
+		if (!$this->skip_auto_mounting and (!isset($destination_external_fixed, $target_mount_point))) {
 			echo "Can't find where and how $destination_external is mounted, probably it is not on BTRFS partition?\n";
 			echo "Creating backup $snapshot of $source to $destination_external failed\n";
 			return;
 		}
+		if ($this->action_send_pre) {
+			$this->exec("$action_snapshot_pre", "Running pre-send action");
+		}
 		if ($common_snapshot) {
 			$this->exec(
-				"$btrfs_send_cmd send -p \"$destination/$common_snapshot\" \"$destination/$snapshot\" | $btrfs_receive_cmd receive $destination_external_fixed",
+				"$this->btrfs_send_cmd send -p \"$destination/$common_snapshot\" \"$destination/$snapshot\" | $this->btrfs_receive_cmd receive $destination_external_fixed",
 				'Making incremental backup'
 			);
 			$type = 'incremental backup';
 		} else {
 			$this->exec(
-				"$btrfs_send_cmd send  \"$destination/$snapshot\" | $btrfs_receive_cmd receive $destination_external_fixed",
+				"$this->btrfs_send_cmd send  \"$destination/$snapshot\" | $this->btrfs_receive_cmd receive $destination_external_fixed",
 				'Making full backup'
 			);
 			$type = 'backup';
@@ -273,15 +324,20 @@ class Just_backup_btrfs {
 		} else {
 			$this->cleanup($history_db_external, $destination_external, $minimum_delete_count);
 			echo "Creating $type $snapshot of $source to $destination_external finished successfully\n";
+			if ($this->action_receive_post) {
+				$this->exec("$this->action_receive_post", "Running post-receive action");
+			}
 		}
-		if (!$config['optimize_mounts']) {
-			$this->exec(
-				"umount $target_mount_point",
-				'Unmounting root subvolume'
-			);
-			rmdir($target_mount_point);
-		} else {
-			echo "Unmounting root subvolume skipped\n";
+		if (!$this->skip_auto_mounting) {
+			if (!$config['optimize_mounts']) {
+				$this->exec(
+					"umount $target_mount_point",
+					'Unmounting root subvolume'
+				);
+				rmdir($target_mount_point);
+			} else {
+				echo "Unmounting root subvolume skipped\n";
+			}
 		}
 	}
 	protected function determine_mount_point ($destination_external) {
@@ -412,7 +468,7 @@ class Just_backup_btrfs {
 	 */
 	protected function cleanup ($history_db, $destination, $minimum_delete_count) {
 		foreach ($this->snapshots_for_removal($history_db, $minimum_delete_count) as $snapshot_for_removal) {
-			$this->exec("$btrfs_cmd subvolume delete \"$destination/$snapshot_for_removal\"");
+			$this->exec("$this->btrfs_cmd subvolume delete \"$destination/$snapshot_for_removal\"");
 			if (file_exists("$destination/$snapshot_for_removal")) {
 				echo "Removing old snapshot $snapshot_for_removal from $destination failed\n";
 				continue;

--- a/just-backup-btrfs
+++ b/just-backup-btrfs
@@ -30,6 +30,7 @@ class Just_backup_btrfs {
 		if (!$config) {
 			exit("Incorrect configuration, aborted\n");
 		}
+		// TODO: if $btrfs_cmd is set, this is not needed
 		$this->config = $config;
 		if (file_exists('/usr/sbin/btrfs')) {
 			$this->binary = '/usr/sbin/btrfs';
@@ -57,6 +58,14 @@ class Just_backup_btrfs {
 		$source               = $config['source_mounted_volume'];
 		$destination          = $config['destination_within_partition'];
 		$minimum_delete_count = $config['minimum_delete_count'];
+		/* custom btrfs command for local operations */
+		$btrfs_cmd            = @$config['btrfs_cmd'] ?: $this->binary;
+		/* custom commands in `btrfs send | btrfs receive` pipe,
+		 * allow to use ssh on both sides of the pipe,
+		 * example: "btrfs_send_cmd" : "ssh username@host btrfs" */
+		$btrfs_send_cmd       = @$config['btrfs_send_cmd'] ?: $this->binary;
+		$btrfs_receive_cmd    = @$config['btrfs_receive_cmd'] ?: $this->binary;
+		// TODO: check that commands are really available
 
 		$history_db = $this->init_database($destination);
 		if (!$history_db) {
@@ -95,7 +104,7 @@ class Just_backup_btrfs {
 			return;
 		}
 
-		$this->exec("$this->binary subvolume snapshot -r \"$source\" \"$destination/$snapshot\"");
+		$this->exec("$btrfs_cmd subvolume snapshot -r \"$source\" \"$destination/$snapshot\"");
 		$this->exec("sync"); // To actually write snapshot to disk
 		if (!file_exists("$destination/$snapshot")) {
 			echo "Snapshot creation for $source failed\n";
@@ -248,13 +257,13 @@ class Just_backup_btrfs {
 		}
 		if ($common_snapshot) {
 			$this->exec(
-				"$this->binary send -p \"$destination/$common_snapshot\" \"$destination/$snapshot\" | $this->binary receive $destination_external_fixed",
+				"$btrfs_send_cmd send -p \"$destination/$common_snapshot\" \"$destination/$snapshot\" | $btrfs_receive_cmd receive $destination_external_fixed",
 				'Making incremental backup'
 			);
 			$type = 'incremental backup';
 		} else {
 			$this->exec(
-				"$this->binary send  \"$destination/$snapshot\" | $this->binary receive $destination_external_fixed",
+				"$btrfs_send_cmd send  \"$destination/$snapshot\" | $btrfs_receive_cmd receive $destination_external_fixed",
 				'Making full backup'
 			);
 			$type = 'backup';
@@ -403,7 +412,7 @@ class Just_backup_btrfs {
 	 */
 	protected function cleanup ($history_db, $destination, $minimum_delete_count) {
 		foreach ($this->snapshots_for_removal($history_db, $minimum_delete_count) as $snapshot_for_removal) {
-			$this->exec("$this->binary subvolume delete \"$destination/$snapshot_for_removal\"");
+			$this->exec("$btrfs_cmd subvolume delete \"$destination/$snapshot_for_removal\"");
 			if (file_exists("$destination/$snapshot_for_removal")) {
 				echo "Removing old snapshot $snapshot_for_removal from $destination failed\n";
 				continue;

--- a/just-backup-btrfs
+++ b/just-backup-btrfs
@@ -74,6 +74,7 @@ class Just_backup_btrfs {
 		$source               = $config['source_mounted_volume'];
 		$destination          = $config['destination_within_partition'];
 		$minimum_delete_count = $config['minimum_delete_count'];
+		$snapshot_name_prefix = @$config['snapshot_name_prefix'] ?: null;
 		/* custom btrfs command for local operations */
 		$this->btrfs_cmd      = @$config['btrfs_cmd'] ?: $this->binary;
 		/* custom commands in `btrfs send | btrfs receive` pipe,
@@ -125,7 +126,11 @@ class Just_backup_btrfs {
 			return;
 		}
 		$date             = time();
-		$snapshot         = date($config['date_format'], $date);
+		if ($snapshot_name_prefix) {
+			$snapshot = $snapshot_name_prefix . "__" . date($config['date_format'], $date);
+		} else {
+			$snapshot = date($config['date_format'], $date);
+		}
 		$snapshot_escaped = $history_db::escapeString($snapshot);
 		$comment          = ''; //TODO Comments support
 		if (!$history_db->exec(

--- a/just-backup-btrfs
+++ b/just-backup-btrfs
@@ -40,6 +40,8 @@ class Just_backup_btrfs {
 		/* Run trap_exit() on any exit from do_backup()
 		 * to guarantee thet post-snapshot action is performed,
 		 * e.g. volume is unmounted */
+		// TODO: works as expected only if one mount point is snapshotted
+		// TODO: make an array of action_snapshot_post and run all of them
 		register_shutdown_function(array($this, 'trap_exit'));
 		// TODO: if $this->btrfs_cmd is set, this is not needed
 		$this->config = $config;
@@ -65,6 +67,7 @@ class Just_backup_btrfs {
 		];
 		foreach ($this->config as $local_config) {
 			$this->do_backup($local_config + $default_config);
+			$this->trap_exit();
 		}
 	}
 	/**

--- a/just-backup-btrfs
+++ b/just-backup-btrfs
@@ -119,7 +119,7 @@ class Just_backup_btrfs {
 			$this->exec("$action_snapshot_pre", "Running pre-snapshot action");
 		}
 
-		$history_db = $this->init_database($destination);
+		$history_db = $this->init_database($destination, $snapshot_name_prefix);
 		if (!$history_db) {
 			return;
 		}
@@ -192,16 +192,23 @@ class Just_backup_btrfs {
 	 *
 	 * @return false|SQLite3
 	 */
-	protected function init_database ($destination) {
+	protected function init_database ($destination, $prefix) {
 		if (!file_exists($destination) && !@mkdir($destination, 0755, true)) {
 			echo "Creating backup destination $destination failed, check permissions\n";
 			return false;
 		}
 
-		$history_db = new SQLite3("$destination/history.db");
+		if ($prefix) {
+			$db_file_name = $destination . "/" . $prefix . "__" . "history.db";
+		} else {
+			$db_file_name = $destination . "/" . "history.db";
+		}
+		$history_db = new SQLite3($db_file_name);
 		if (!$history_db) {
-			echo "Opening database $destination/history.db failed, check permissions\n";
+			echo "Opening database $db_file_name failed, check permissions\n";
 			return false;
+		} else {
+			echo "Openned database " . $db_file_name . PHP_EOL;
 		}
 
 		$history_db->exec(
@@ -232,7 +239,7 @@ class Just_backup_btrfs {
 		$destination          = $config['destination_within_partition'];
 		$destination_external = $config['destination_other_partition'];
 		$minimum_delete_count = @$config['minimum_delete_count_other'] ?: $config['minimum_delete_count'];
-		$history_db_external  = $this->init_database($destination_external);
+		$history_db_external  = $this->init_database($destination_external, $snapshot_name_prefix);
 		if (!$history_db_external) {
 			return;
 		}


### PR DESCRIPTION
Hi, thanks for this script, I have adopted it a bit for my needs. What I have done is not finished, but it works for my needs and may be will intreset you.

* added ability to set custom `btrfs` command
* added ability to set custom `btrfs` commands in send/receive pipeline, I thought to use it for SSH but then undestood that rewriting the logics of how existence of snapshots is checked is required, so it exists but may be useless
* prefix `history.db` filename with a custom name: this fixes the work when there are multiple snapshottable subvolumes in one root
* added pre/post actions to run before and after the snapshot.

I use pre/post snapshot actions to mount and umount a root subvolume inside which there are multiple snapshottable subvolumes. I tried to add a trap to catch any exit of the script, including the ones when it exists somewhere in the middle dut to errors to guarantee unmounting what was mounted as a pre-snapshot action, but faced a problem that it does not work well when multiple snapshots are defined in one json config. And I faced some other problems when multiple snapshots are defined in one json config, already do not remember details.
As I am not good in php, I ended up with a shell script like `for i in config1.json config2.json config3.json; do just-backup-btrfs "$i" ; done`.

Example of my json config:
```
[
	{
		"snapshot_name_prefix"	       : "gitea",
		"action_snapshot_pre"          : "mkdir -p /tmp/_jbb/gitea/ && chmod 700 /tmp/_jbb/gitea/ && mount /dev/disk/by-uuid/xxxxxxx /tmp/_jbb/gitea/",
		"action_snapshot_post"         : "umount /tmp/_jbb/gitea/",
		"source_mounted_volume"        : "/tmp/_jbb/gitea/@gitea",
		"destination_within_partition" : "/tmp/_jbb/gitea/jbb_snaps/gitea/",
		"destination_other_partition"  : null,
		"date_format"                  : "Y-m-d_H:i:s",
		"btrfs_cmd"		               : "btrfs",
		"skip_auto_mounting"           : "true",
		"keep_snapshots"               : {
			"hour"  : 6,
			"day"   : 24,
			"month" : 30,
			"year"  : 48
		}
	}
] 
```

Plus I use `btrfs-sync` script https://github.com/nachoparker/btrfs-sync to send incremental backups to another server.